### PR TITLE
Improve generated wiki markup.

### DIFF
--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -88,7 +88,7 @@ public class ExtensionPointListGenerator {
             for (ExtensionSummary e : implementations) {
                 w.println("h3."+e.implementation);
                 w.println(getSynopsis(e));
-                w.println(e.confluenceDoc);
+                w.println(e.confluenceDoc == null ? "_This extension point has no JavaDoc documentation._" : e.confluenceDoc);
             }
             if (implementations.isEmpty())
                 w.println("(No known implementation)");
@@ -100,8 +100,12 @@ public class ExtensionPointListGenerator {
             final Module m = modules.get(e.artifact);
             if (m==null)
                 throw new IllegalStateException("Unable to find module for "+e.artifact);
-            return MessageFormat.format("*Defined in*: {0}  ([javadoc|{1}@javadoc])\n",
-                    m.getWikiLink(), e.extensionPoint);
+            if ("Jenkins Core".equals(m.displayName)) {
+                return MessageFormat.format("*Defined in*: {0}  ([javadoc|{1}@javadoc])\n",
+                        m.getWikiLink(), e.extensionPoint);
+            } else {
+                return MessageFormat.format("*Defined in*: {0}\n", m.getWikiLink());
+            }
         }
 
         public int compareTo(Object that) {


### PR DESCRIPTION
* Don't generate JavaDoc links for plugins, they don't work
* Don't print 'null' but a real message when there's no JavaDoc