### PR TITLE
Clear zip file cache

### DIFF
--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointsExtractor.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointsExtractor.java
@@ -7,6 +7,7 @@ import com.sun.source.util.TreePath;
 import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
 import com.sun.tools.javac.api.JavacTool;
+import com.sun.tools.javac.file.ZipFileIndexCache;
 import org.apache.commons.io.IOUtils;
 import org.jvnet.hudson.update_center.MavenArtifact;
 
@@ -121,6 +122,7 @@ public class ExtensionPointsExtractor {
             if (fileManager!=null)
                 fileManager.close();
             sal.close();
+            ZipFileIndexCache.getSharedInstance().clearCache();
         }
     }
 


### PR DESCRIPTION
New javac has a cache for zip files that causes extension indexer to OOM, so clear it early and often.