### PR TITLE
skip python-wrapper to remove noise

### DIFF
--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -234,6 +234,9 @@ public class ExtensionPointListGenerator {
                 if (!args.isEmpty()) {
                     if (!args.contains(p.artifactId))
                         continue;   // skip
+                } else if ("python-wrapper".equals(p.artifactId)) {
+                    // python-wrapper does not have extension points but just wrappers to help python plugins use extension points
+                    continue;   // skip them to remove noise
                 }
                 futures.add(svc.submit(new Runnable() {
                     public void run() {

--- a/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
+++ b/src/main/java/org/jenkinsci/extension_indexer/ExtensionPointListGenerator.java
@@ -236,6 +236,7 @@ public class ExtensionPointListGenerator {
                         continue;   // skip
                 } else if ("python-wrapper".equals(p.artifactId)) {
                     // python-wrapper does not have extension points but just wrappers to help python plugins use extension points
+                    // see https://issues.jenkins-ci.org/browse/INFRA-516
                     continue;   // skip them to remove noise
                 }
                 futures.add(svc.submit(new Runnable() {


### PR DESCRIPTION
python-wrapper does not implement all extension points but has just wrappers for all of them, to help python plugins use extension points. This PR is to skip python-wrapper to remove noise.